### PR TITLE
Pin the nodesource nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,14 +18,13 @@ ENV APP_HOME=/var/local/dataviz \
 RUN runDeps="vim git curl cron netcat-traditional gnupg" \
  && apt-get update -y \
  && apt-get install -y --no-install-recommends $runDeps \
- && apt-get clean \
- && rm -vrf /var/lib/apt/lists/* \
  && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
  && echo 'Package: *' > /etc/apt/preferences.d/nodesource \
  && echo 'Pin: origin deb.nodesource.com' >> /etc/apt/preferences.d/nodesource \
  && echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/nodesource \
  && apt-get install -y nodejs \
  && curl -sL https://sentry.io/get-cli/ | bash \
+ && rm -rf /var/lib/apt/lists/* \
  && mkdir -p $APP_HOME \
  && mkdir -p /var/local/logs \
  && touch ~/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim
+FROM python:3.6-slim-buster
 
 ENV PYTHONUNBUFFERED=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN runDeps="vim git curl cron netcat-traditional gnupg" \
  && apt-get clean \
  && rm -vrf /var/lib/apt/lists/* \
  && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+ && echo 'Package: *' > /etc/apt/preferences.d/nodesource \
+ && echo 'Pin: origin deb.nodesource.com' >> /etc/apt/preferences.d/nodesource \
+ && echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/nodesource \
  && apt-get install -y nodejs \
  && curl -sL https://sentry.io/get-cli/ | bash \
  && mkdir -p $APP_HOME \


### PR DESCRIPTION
The base image (`python:3.6-slim`) is currently based on Debian Buster. Our build probably broke when the Python docker images transitioned to Buster, which ships with its own nodejs, thereby breaking the nodesource install script. I've pinned the base image to buster in case this sort of thing happens again.

By the way, we should upgrade to a newer nodejs, version 8 is no longer maintained.