### PR TITLE
Deploy to Azure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### project-related files
 dv/localsettings.py
 docker/web.env
+docker/azure-web.env
 docker/azure-nginx.env
 
 ### generic stuff

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### project-related files
 dv/localsettings.py
 docker/web.env
+docker/azure-nginx.env
 
 ### generic stuff
 __pycache__/

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,6 +25,7 @@ These instructions assume you're deploying to Azure Containers, and have already
     docker volume create --storage-account eeagstorage weblogs
     docker volume create --storage-account eeagstorage webroot
     docker volume create --storage-account eeagstorage nginxconfig
+    docker volume create --storage-account eeagstorage upload
     ```
 
 1. Upload nginx configuration:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,6 +11,12 @@ These instructions assume you're deploying to Azure Containers, and have already
     source docker/set_context.sh eeagstaging
     ```
 
+1. Configure environment variables – copy and modify the examples:
+    ```shell
+    cp docker/web.prod.env.example docker/web.env
+    cp docker/azure-nginx.env.example docker/azure-nginx.env
+    ```
+
 1. Create volumes:
     ```shell
     docker volume create --storage-account eeagstorage solrhome

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -26,4 +26,32 @@ These instructions assume you're deploying to Azure Containers, and have already
     az storage copy -s docker/nginx.conf -d 'https://eeagstorage.file.core.windows.net/nginxconfig/nginx.conf'
     docker exec -it dataviz_nginx sh  # log in to nginx container
     kill -HUP 1  # reload nginx configuration
+    exit  # log out of nginx container
+    ```
+
+1. Upload existing database file:
+    ```shell
+    az storage copy -s eeag.sqlite3 -d 'https://eeagstorage.file.core.windows.net/webdb/eeag.sqlite3'
+    ```
+
+1. Reload Solr schema:
+    ```shell
+    docker exec -it dataviz_web bash  # log in to web container
+    ./manage.py build_solr_schema --filename /var/local/db/schema.xml
+    ./manage.py patch_schema /var/local/db/schema.xml
+    exit  # log out of web container
+
+    az storage copy -s 'https://eeagstorage.file.core.windows.net/webdb/schema.xml' -d 'https://eeagstorage.file.core.windows.net/solrhome/eeagrants/conf/schema.xml'
+
+    docker exec -it dataviz_solr bash  # log in to solr container
+    rm /solr_home/eeagrants/conf/managed-schema
+    curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=eeagrants"
+    exit  # log out of solr container
+    ```
+
+1. Rebuild indexes:
+    ```shell
+    docker exec -it dataviz_web bash  # log in to web container
+    ./manage.py rebuild_index --noinput
+    exit  # log out of web container
     ```

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -26,12 +26,10 @@ These instructions assume you're deploying to Azure Containers, and have already
     docker compose -f docker-compose-azure.yml up
     ```
 
-1. Upload nginx configuration and reload nginx:
+1. Upload nginx configuration:
     ```shell
-    az storage copy -s docker/nginx.conf -d 'https://eeagstorage.file.core.windows.net/nginxconfig/nginx.conf'
-    docker exec -it dataviz_nginx sh  # log in to nginx container
-    kill -HUP 1  # reload nginx configuration
-    exit  # log out of nginx container
+    az storage copy -s docker/azure-nginx.conf -d 'https://eeagstorage.file.core.windows.net/nginxconfig/nginx.conf'
+    az storage copy -s docker/azure-entrypoint.sh -d 'https://eeagstorage.file.core.windows.net/nginxconfig/entrypoint.sh'
     ```
 
 1. Upload existing database file:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -11,11 +11,37 @@ These instructions assume you're deploying to Azure Containers, and have already
     source docker/set_context.sh eeagstaging
     ```
 
-1. Configure environment variables – copy and modify the examples:
-    ```shell
-    cp docker/web.prod.env.example docker/web.env
-    cp docker/azure-nginx.env.example docker/azure-nginx.env
-    ```
+1. Set up secrets
+
+    1. If it's a first-time deployment, set up a Key Vault:
+
+        ```shell
+        az keyvault create --location northeurope --name eeagsecrets --resource-group eeagstaging
+        ```
+
+       Then enter secrets:
+
+        ```shell
+        az keyvault secret set --vault-name eeagsecrets --name secret-key --value 'not-so-secret'
+        ```
+
+       The following secrets are required:
+
+       * `allowed-hosts`: Domain name for the site.
+       * `secret-key`: A random string for Django's `SECRET_KEY` setting.
+       * `frontend-sentry-dsn`: Sentry DSN for the front-end.
+       * `sentry-dsn`: Sentry DSN for the back-end.
+       * `sentry-environment`: Sentry environment name.
+       * `google-analytics-property-id`: Google Analytics tracking ID, e.g. `UA-12345-1`.
+       * `fqdn`: Domain name for the site.
+       * `certbot-email`: Email to use when requesting a certificate from Let's Encrypt. Used for [Expiration Emails](https://letsencrypt.org/docs/expiration-emails/).
+
+    1. Download secrets and generate a configuration file:
+
+        ```shell
+        docker/azure-get-secrets.py eeagsecrets web > docker/azure-web.env
+        docker/azure-get-secrets.py eeagsecrets nginx > docker/azure-nginx.env
+        ```
 
 1. Create volumes:
     ```shell

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -21,20 +21,26 @@ These instructions assume you're deploying to Azure Containers, and have already
     docker volume create --storage-account eeagstorage nginxconfig
     ```
 
-1. Deploy the app:
-    ```shell
-    docker compose -f docker-compose-azure.yml up
-    ```
-
 1. Upload nginx configuration:
     ```shell
     az storage copy -s docker/azure-nginx.conf -d 'https://eeagstorage.file.core.windows.net/nginxconfig/nginx.conf'
     az storage copy -s docker/azure-entrypoint.sh -d 'https://eeagstorage.file.core.windows.net/nginxconfig/entrypoint.sh'
     ```
 
-1. Upload existing database file:
+1. Prepare the database file to work on Azure persistent volumes:
+    ```shell
+    sqlite3 eeag.sqlite3
+    sqlite> PRAGMA journal_mode=wal;
+    ```
+
+1. Upload the database file:
     ```shell
     az storage copy -s eeag.sqlite3 -d 'https://eeagstorage.file.core.windows.net/webdb/eeag.sqlite3'
+    ```
+
+1. Deploy the app:
+    ```shell
+    docker compose -f docker-compose-azure.yml up
     ```
 
 1. Reload Solr schema:

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -29,7 +29,6 @@ These instructions assume you're deploying to Azure Containers, and have already
 
        * `allowed-hosts`: Domain name for the site.
        * `secret-key`: A random string for Django's `SECRET_KEY` setting.
-       * `frontend-sentry-dsn`: Sentry DSN for the front-end.
        * `sentry-dsn`: Sentry DSN for the back-end.
        * `sentry-environment`: Sentry environment name.
        * `google-analytics-property-id`: Google Analytics tracking ID, e.g. `UA-12345-1`.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -13,7 +13,12 @@ These instructions assume you're deploying to Azure Containers, and have already
 
 1. Create volumes:
     ```shell
-    (set +x; for name in solrhome solrlogs webdb weblogs webroot nginxconfig; do docker volume create --storage-account eeagstorage $name; done)
+    docker volume create --storage-account eeagstorage solrhome
+    docker volume create --storage-account eeagstorage solrlogs
+    docker volume create --storage-account eeagstorage webdb
+    docker volume create --storage-account eeagstorage weblogs
+    docker volume create --storage-account eeagstorage webroot
+    docker volume create --storage-account eeagstorage nginxconfig
     ```
 
 1. Deploy the app:

--- a/assets/dataviz.js
+++ b/assets/dataviz.js
@@ -20,7 +20,9 @@ if (process.env.NODE_ENV === "production") {
   console.info("Running in production mode! Enabling Sentry.");
 
   Raven
-    .config(process.env.FRONTEND_SENTRY_DSN)
+    .config(window._dv_sentry_config.dsn, {
+      environment: window._dv_sentry_config.environment
+    })
     .addPlugin(RavenVue, Vue)
     .install();
 }

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -32,21 +32,24 @@ services:
 
   nginx:
     domainname: eeagstaging
-    image: nginx:1.13-alpine
+    # TODO use version tag when they are available
+    # https://github.com/staticfloat/docker-nginx-certbot/issues/29
+    image: staticfloat/nginx-certbot:latest
     depends_on:
       - web
     volumes:
       - webroot:/var/local/webroot:ro
-      - nginxconfig:/etc/nginx/conf.d:ro
+      - nginxconfig:/nginxconfig
     deploy:
       resources:
         limits:
           cpus: "0.2"
           memory: 100M
     restart: unless-stopped
-    command: ["sh", "-c", "set -x; until grep -q web /etc/hosts; do sleep 1; done; exec nginx -g 'daemon off;'"]
+    command: ["/bin/bash", "/nginxconfig/entrypoint.sh"]
     ports:
       - 80:80
+      - 443:443
 
 volumes:
   webroot:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -40,6 +40,8 @@ services:
     volumes:
       - webroot:/var/local/webroot:ro
       - nginxconfig:/nginxconfig
+    env_file:
+      - docker/azure-nginx.env
     deploy:
       resources:
         limits:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -38,6 +38,7 @@ services:
     - webroot:/var/local/webroot:ro
     - nginxconfig:/etc/nginx/conf.d:ro
     restart: "always"
+    command: ["sh", "-c", "(set -x; until grep -q web /etc/hosts; do sleep 1; done); echo 'web ready; starting nginx'; exec nginx -g 'daemon off;'"]
 
 volumes:
   webroot:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -39,6 +39,8 @@ services:
     - nginxconfig:/etc/nginx/conf.d:ro
     restart: "always"
     command: ["sh", "-c", "set -x; until grep -q web /etc/hosts; do sleep 1; done; exec nginx -g 'daemon off;'"]
+    ports:
+      - 80:80
 
 volumes:
   webroot:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -31,12 +31,18 @@ services:
     restart: "always"
 
   nginx:
+    domainname: eeagstaging
     image: nginx:1.13-alpine
     depends_on:
     - web
     volumes:
     - webroot:/var/local/webroot:ro
     - nginxconfig:/etc/nginx/conf.d:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "0.2"
+          memory: 100M
     restart: "always"
     command: ["sh", "-c", "set -x; until grep -q web /etc/hosts; do sleep 1; done; exec nginx -g 'daemon off;'"]
     ports:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -28,6 +28,7 @@ services:
       - weblogs:/var/local/logs
       - webdb:/var/local/db
       - webroot:/var/local/webroot
+      - upload:/var/local/upload
     restart: unless-stopped
 
   nginx:
@@ -83,4 +84,9 @@ volumes:
     driver: azure_file
     driver_opts:
       share_name: nginxconfig
+      storage_account_name: eeagstorage
+  upload:
+    driver: azure_file
+    driver_opts:
+      share_name: upload
       storage_account_name: eeagstorage

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -38,7 +38,7 @@ services:
     - webroot:/var/local/webroot:ro
     - nginxconfig:/etc/nginx/conf.d:ro
     restart: "always"
-    command: ["sh", "-c", "(set -x; until grep -q web /etc/hosts; do sleep 1; done); echo 'web ready; starting nginx'; exec nginx -g 'daemon off;'"]
+    command: ["sh", "-c", "set -x; until grep -q web /etc/hosts; do sleep 1; done; exec nginx -g 'daemon off;'"]
 
 volumes:
   webroot:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -23,7 +23,7 @@ services:
     environment:
       - NUM_WORKERS=3
     env_file:
-      - docker/web.env
+      - docker/azure-web.env
     volumes:
       - weblogs:/var/local/logs
       - webdb:/var/local/db
@@ -41,6 +41,8 @@ services:
     volumes:
       - webroot:/var/local/webroot:ro
       - nginxconfig:/nginxconfig
+    environment:
+      - ENVSUBST_VARS=FQDN
     env_file:
       - docker/azure-nginx.env
     deploy:

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -1,0 +1,72 @@
+version: '2'
+services:
+  solr:
+    image: solr:6.6.4
+    user: root
+    environment:
+      - TZ=Europe/Brussels
+      - SOLR_HOME=/solr_home
+      - SOLR_HEAP=256m
+      - SOLR_TIMEZONE=CET
+      - SOLR_LOG_LEVEL=CONFIG
+      - SOLR_LOGS_DIR=/solr_logs
+      - INIT_SOLR_HOME=yes
+      # LOG4J_PROPS=/var/solr/log4j.properties
+    volumes:
+      - solrhome:/solr_home
+      - solrlogs:/solr_logs
+    restart: "always"
+
+
+  web:
+    image: eftafmo/dataviz:latest
+    environment:
+      - NUM_WORKERS=3
+    env_file:
+      - docker/web.env
+    volumes:
+      - weblogs:/var/local/logs
+      - webdb:/var/local/db
+      - webroot:/var/local/webroot
+    restart: "always"
+
+  nginx:
+    image: nginx:1.13-alpine
+    depends_on:
+    - web
+    volumes:
+    - webroot:/var/local/webroot:ro
+    - nginxconfig:/etc/nginx/conf.d:ro
+    restart: "always"
+
+volumes:
+  webroot:
+    driver: azure_file
+    driver_opts:
+      share_name: webroot
+      storage_account_name: eeagstorage
+  webdb:
+    driver: azure_file
+    driver_opts:
+      share_name: webdb
+      storage_account_name: eeagstorage
+  weblogs:
+    driver: azure_file
+    driver_opts:
+      share_name: weblogs
+      storage_account_name: eeagstorage
+  solrhome:
+    driver: azure_file
+    driver_opts:
+      share_name: solrhome
+      storage_account_name: eeagstorage
+  solrlogs:
+    driver: azure_file
+    driver_opts:
+      share_name: solrlogs
+      storage_account_name: eeagstorage
+  nginxconfig:
+    driver: azure_file
+    driver_opts:
+      share_name: nginxconfig
+      storage_account_name: eeagstorage

--- a/docker-compose-azure.yml
+++ b/docker-compose-azure.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - solrhome:/solr_home
       - solrlogs:/solr_logs
-    restart: "always"
+    restart: unless-stopped
 
 
   web:
@@ -28,22 +28,22 @@ services:
       - weblogs:/var/local/logs
       - webdb:/var/local/db
       - webroot:/var/local/webroot
-    restart: "always"
+    restart: unless-stopped
 
   nginx:
     domainname: eeagstaging
     image: nginx:1.13-alpine
     depends_on:
-    - web
+      - web
     volumes:
-    - webroot:/var/local/webroot:ro
-    - nginxconfig:/etc/nginx/conf.d:ro
+      - webroot:/var/local/webroot:ro
+      - nginxconfig:/etc/nginx/conf.d:ro
     deploy:
       resources:
         limits:
           cpus: "0.2"
           memory: 100M
-    restart: "always"
+    restart: unless-stopped
     command: ["sh", "-c", "set -x; until grep -q web /etc/hosts; do sleep 1; done; exec nginx -g 'daemon off;'"]
     ports:
       - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,7 @@ services:
   solr:
     image: solr:6.6.4
     container_name: eeag_solr
-    depends_on:
-      - solrvolumefixer
-    volumes_from:
-      - solrvolumefixer
+    user: root
     environment:
       - TZ=Europe/Brussels
       - SOLR_HOME=/solr_home
@@ -16,21 +13,11 @@ services:
       - SOLR_LOGS_DIR=/solr_logs
       - INIT_SOLR_HOME=yes
       # LOG4J_PROPS=/var/solr/log4j.properties
-    entrypoint:
-      - docker-entrypoint.sh
-      - solr-precreate
-      - eeagrants
-    restart: "always"
-
-  solrvolumefixer:
-    image: solr:6.6.4
-    container_name: eeag_solrvolumefixer
-    user: root
     volumes:
       - solr_home:/solr_home
       - solr_logs:/solr_logs
-    entrypoint: ["chown"]
-    command: ["-R", "8983:8983", "/solr_home", "/solr_logs"]
+    command: ["bash", "-c", "chown solr: /solr_home /solr_logs && exec gosu solr docker-entrypoint.sh solr-precreate eeagrants"]
+    restart: "always"
 
 
   web:

--- a/docker/azure-entrypoint.sh
+++ b/docker/azure-entrypoint.sh
@@ -22,10 +22,14 @@ tar cz -C /etc letsencrypt > $LETSENCRYPT_BACKUP
 EOF
 
 echo "Hacking /scripts/util.sh to call backup script when it's done"
-cat >> /scripts/util.sh <<EOF
+if ! [ -f /scripts/util-orig.sh ]; then
+  cp /scripts/util.sh /scripts/util-orig.sh
+fi
+cat > /scripts/util.sh <<EOF
+source /scripts/util-orig.sh
 eval "\$(echo "orig_get_certificate()"; declare -f get_certificate | tail -n +2)"
 get_certificate() {
-  orig_get_certificate
+  orig_get_certificate "\$@"
   bash /backup-letsencrypt.sh
 }
 EOF

--- a/docker/azure-entrypoint.sh
+++ b/docker/azure-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e;
+
+# copy nginx user config files
+NGINX_USER_CONF=/etc/nginx/user.conf.d/
+echo "Copying user config files to $NGINX_USER_CONF"
+mkdir -p $NGINX_USER_CONF
+(set -x; cp /nginxconfig/*.conf $NGINX_USER_CONF)
+
+LETSENCRYPT_BACKUP=/nginxconfig/letsencrypt.tgz
+if [ -f /nginxconfig/letsencrypt.tgz ]; then
+  echo "Restoring letsencrypt data from $LETSENCRYPT_BACKUP"
+  tar xz -C /etc < $LETSENCRYPT_BACKUP
+fi
+
+echo "Installing letsencrypt backup hook"
+cat > /backup-letsencrypt.sh <<EOF
+#!/bin/bash
+set -x
+tar cz -C /etc letsencrypt > $LETSENCRYPT_BACKUP
+EOF
+
+echo "Hacking /scripts/util.sh to call backup script when it's done"
+cat >> /scripts/util.sh <<EOF
+eval "\$(echo "orig_get_certificate()"; declare -f get_certificate | tail -n +2)"
+get_certificate() {
+  orig_get_certificate
+  bash /backup-letsencrypt.sh
+}
+EOF
+
+
+until grep -q web /etc/hosts; do
+  echo "Waiting for 'web' in /etc/hosts ..."
+  sleep 1
+done
+echo "Found 'web' in /etc/hosts, proceeding"
+
+echo "Setting up environment variables"
+export CERTBOT_EMAIL="eeagrants@edw.ro"
+export ENVSUBST_VARS="FQDN"
+export FQDN="eeagrants-azure.edw.ro"
+
+echo "Running default entrypoint /scripts/entrypoint.sh ..."
+exec /scripts/entrypoint.sh

--- a/docker/azure-entrypoint.sh
+++ b/docker/azure-entrypoint.sh
@@ -41,10 +41,5 @@ until grep -q web /etc/hosts; do
 done
 echo "Found 'web' in /etc/hosts, proceeding"
 
-echo "Setting up environment variables"
-export CERTBOT_EMAIL="eeagrants@edw.ro"
-export ENVSUBST_VARS="FQDN"
-export FQDN="eeagrants-azure.edw.ro"
-
 echo "Running default entrypoint /scripts/entrypoint.sh ..."
 exec /scripts/entrypoint.sh

--- a/docker/azure-get-secrets.py
+++ b/docker/azure-get-secrets.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+import json
+
+VARS = {
+    "web": [
+        "allowed-hosts",
+        "secret-key",
+        "frontend-sentry-dsn",
+        "sentry-dsn",
+        "sentry-environment",
+        "google-analytics-property-id",
+    ],
+    "nginx": [
+        "fqdn",
+        "certbot-email",
+    ],
+}
+
+
+def get_secret(vault_name, name):
+    resp = subprocess.check_output([
+        "az", "keyvault", "secret", "show",
+        "--vault-name", vault_name,
+        "--name", name,
+    ])
+    return json.loads(resp)["value"]
+
+
+def main(vault_name, service):
+    for name in VARS[service]:
+        env_var = name.upper().replace("-", "_")
+        value = get_secret(vault_name, name)
+        print(f'{env_var}={value}')
+
+if __name__ == "__main__":
+    [vault_name, service] = sys.argv[1:]
+    main(vault_name, service)

--- a/docker/azure-get-secrets.py
+++ b/docker/azure-get-secrets.py
@@ -8,7 +8,6 @@ VARS = {
     "web": [
         "allowed-hosts",
         "secret-key",
-        "frontend-sentry-dsn",
         "sentry-dsn",
         "sentry-environment",
         "google-analytics-property-id",

--- a/docker/azure-nginx.conf
+++ b/docker/azure-nginx.conf
@@ -1,0 +1,36 @@
+types {
+  application/json topojson;
+}
+
+upstream djangoapp {
+  server web:8000 fail_timeout=1s;
+}
+
+server {
+  listen              443 ssl;
+  server_name         ${FQDN};
+  ssl_certificate     /etc/letsencrypt/live/${FQDN}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/${FQDN}/privkey.pem;
+
+  access_log /var/log/nginx/access.log main;
+
+  location /assets {
+    sendfile on;
+    tcp_nopush on;
+    gzip on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+    expires 1d;
+    alias /var/local/webroot/static;
+    add_header 'Access-Control-Allow-Origin' "*" always;
+  }
+
+  location / {
+    proxy_pass http://djangoapp;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+    gzip on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+    expires 1h;
+  }
+}

--- a/docker/azure-nginx.env.example
+++ b/docker/azure-nginx.env.example
@@ -1,0 +1,3 @@
+CERTBOT_EMAIL=eeagrants@edw.ro
+ENVSUBST_VARS=FQDN
+FQDN=eeagrants-azure.edw.ro

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -28,6 +28,7 @@ HAYSTACK_CONNECTIONS = {
         'URL': 'http://solr:8983/solr/eeagrants',
         'BATCH_SIZE': 999,
         'SILENTLY_FAIL': False,
+        'TIMEOUT': env("HAYSTACK_SOLR_TIMEOUT", cast=int, default=60),
     },
 }
 

--- a/docker/localsettings.py
+++ b/docker/localsettings.py
@@ -1,7 +1,5 @@
 import os.path
 import environ
-import sentry_sdk
-from sentry_sdk.integrations.django import DjangoIntegration
 
 try:
     BASE_DIR, INSTALLED_APPS
@@ -34,11 +32,6 @@ HAYSTACK_CONNECTIONS = {
 }
 
 GOOGLE_ANALYTICS_PROPERTY_ID = env('GOOGLE_ANALYTICS_PROPERTY_ID')
-
-sentry_sdk.init(
-    dsn=env('SENTRY_DSN'),
-    integrations=[DjangoIntegration()],
-)
 
 # CORS_ORIGIN_ALLOW_ALL = True
 # CORS_ORIGIN_WHITELIST = (,)

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,29 @@
+types {
+  application/json topojson;
+}
+upstream djangoapp {
+  server web:8000 fail_timeout=1s;
+}
+server {
+  listen 8888;
+  access_log /var/log/nginx/access.log main;
+
+  location /assets {
+    sendfile on;
+    tcp_nopush on;
+    gzip on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+    expires 1d;
+    alias /var/local/webroot/static;
+    add_header 'Access-Control-Allow-Origin' "*" always;
+  }
+  location / {
+    proxy_pass http://djangoapp;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+    gzip on;
+    gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript application/vnd.ms-fontobject application/x-font-ttf font/opentype image/svg+xml image/x-icon;
+    expires 1h;
+  }
+}

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,7 +5,7 @@ upstream djangoapp {
   server web:8000 fail_timeout=1s;
 }
 server {
-  listen 8888;
+  listen 80;
   access_log /var/log/nginx/access.log main;
 
   location /assets {

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,9 +1,11 @@
 types {
   application/json topojson;
 }
+
 upstream djangoapp {
   server web:8000 fail_timeout=1s;
 }
+
 server {
   listen 80;
   access_log /var/log/nginx/access.log main;
@@ -17,6 +19,7 @@ server {
     alias /var/local/webroot/static;
     add_header 'Access-Control-Allow-Origin' "*" always;
   }
+
   location / {
     proxy_pass http://djangoapp;
     proxy_set_header Host $host;

--- a/docker/set_context.sh
+++ b/docker/set_context.sh
@@ -1,0 +1,2 @@
+export DOCKER_CONTEXT=$1
+export PS1="[docker:$DOCKER_CONTEXT]$PS1"

--- a/docker/web.staging.env.example
+++ b/docker/web.staging.env.example
@@ -2,6 +2,6 @@ SECRET_KEY=not-so-secret
 ALLOWED_HOSTS=*
 FRONTEND_SENTRY_DSN=https://sentry-random-hash@sentry.io/12345
 SENTRY_DSN=https://sentry-random-hash-1:sentry-random-hash-2@sentry.io/12345
-SENTRY_ENVIRONMENT=prod
-# eeagrants prod
+SENTRY_ENVIRONMENT=staging
+# eeagrants staging
 GOOGLE_ANALYTICS_PROPERTY_ID=UA-12345-1

--- a/dv/context.py
+++ b/dv/context.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 
 def get_context(request):
-    expose_settings = []
+    expose_settings = ['SENTRY_DSN', 'SENTRY_ENVIRONMENT']
     if not settings.DEBUG:
         expose_settings = ['GOOGLE_ANALYTICS_PROPERTY_ID']
 

--- a/dv/settings.py
+++ b/dv/settings.py
@@ -188,6 +188,7 @@ HAYSTACK_CONNECTIONS = {
         'URL': 'http://localhost:8983/solr/eeagrants',
         'BATCH_SIZE': 999,
         'SILENTLY_FAIL': False,
+        'TIMEOUT': env("HAYSTACK_SOLR_TIMEOUT", cast=int, default=60),
     },
 }
 

--- a/dv/settings.py
+++ b/dv/settings.py
@@ -12,6 +12,12 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+import environ
+
+env = environ.Env(DEBUG=(bool, False),)  # set default values and casting
+
 # project's base directory (the repo root)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # root directory, where project is deployed
@@ -195,5 +201,13 @@ CACHES = {
 }
 
 API_CACHE_SECONDS = 60 * 60 * 24  # 1 day
+
+SENTRY_DSN = env('SENTRY_DSN')
+SENTRY_ENVIRONMENT = env('SENTRY_ENVIRONMENT')
+
+sentry_sdk.init(
+    dsn=SENTRY_DSN,
+    integrations=[DjangoIntegration()],
+)
 
 from .localsettings import *

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,6 +69,12 @@
         </div>
       </div>
   </footer>
+  <script>
+    window._dv_sentry_config = {
+      dsn: "{{ settings.SENTRY_DSN|escapejs }}",
+      environment: "{{ settings.SENTRY_ENVIRONMENT|escapejs }}",
+    };
+  </script>
   {% render_bundle 'dataviz' 'js' %}
   {% render_bundle 'site' 'js' %}
 {% block finally %}


### PR DESCRIPTION
The app is currently running at http://51.104.155.248/ in Azure Containers.
* It uses "File shares" in a "Storage account" as Docker volumes for persistent data; they seem to work fine for the app's needs, but they seem to be backed by a non-Linux filesystem (e.g. they are case insensitive and don't respect ownership and permissions). This actually allows us to remove the `solrvolumefixer` service since it's not needed any more.
* Ports can't be re-mapped, so nginx now listens on port 80 in the container as well as outside.
* At startup, the `nginx` container doesn't have a DNS mapping to the `web` container, so I've added a wait loop.
* Volume names must be letters only, no `-` or `_`, so they are now that much more illegible.
* I've tried to keep the azure docker-compose configuration as an overrides file, but it seems volume definitions are not merged properly. Possibly because the Docker Azure integration uses `docker compose` rather than `docker-compose`, and I couldn't find any documentation for it.

In order to set up https, we need to set up a domain name, and TLS a certificate. The setup process is documented at https://github.com/eftafmo/dataviz/blob/azure/INSTALLATION.md.

The current setup is based on Docker Azure Integration (https://docs.docker.com/engine/context/aci-integration/; https://docs.microsoft.com/en-us/azure/container-instances/tutorial-docker-compose). Its documentation includes this warning:

> Docker Azure Integration is currently a beta release. The commands and flags are subject to change in subsequent releases.

There are two more deployment options:

* YAML file (https://docs.microsoft.com/en-us/azure/container-instances/container-instances-multi-container-yaml)
* Resource Manager template (https://docs.microsoft.com/en-us/azure/container-instances/container-instances-multi-container-group)

They don't seem to offer much more in terms of flexibility though.

I also found an unexpected limitation: each container consumes 1 unit of CPU, while the CPU limit for containers in Azure regions is 4 (sometimes even less: https://docs.microsoft.com/en-us/azure/container-instances/container-instances-region-availability). Our app has 3 containers (solr, web, nginx) plus a dns sidecar container (introduced by the Docker integration or the Azure infrastructure, I'm not sure) which means we can't add any more containers to the group.


---

* [x] Get a basic configuration working on Azure
* [x] Expose the app ~using https~ using plain http on port 80
* [x] Documentation